### PR TITLE
Bake results/ folder to the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ endif
 	$(NEURO) kill $(SETUP_JOB)
 
 .PHONY: __bake
-__bake: upload-code upload-data upload-notebooks
+__bake: upload-code upload-data upload-notebooks upload-results
 	echo "#!/usr/bin/env bash" > /tmp/jupyter.sh
 	echo "jupyter notebook \
             --no-browser \


### PR DESCRIPTION
Fixes https://neuromation.slack.com/archives/CU7EY0YRE/p1585692797004400:
```
Turned out that our Midi Generator recipe doesn't work in Web. The problem is that pretrained models for inference reside in '/results' directory, which is not copied in the baked image.
```
