### PR TITLE
Set tests failing if any test failed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
           neuro config show
       - name: Build and test image
         run: |
+          set -e
           source venv/bin/activate
 
           export CUSTOM_ENV_NAME=image:$IMAGE_NAME:$IMAGE_TAG


### PR DESCRIPTION
now, without `set -e`, even if `make test` failed, the github actions step will continue its execution.