### PR TITLE
Fix tests: set -o pipefail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           neuro config show
       - name: Build and test image
         run: |
-          set -e
+          set -e -o pipefail
           source venv/bin/activate
 
           export CUSTOM_ENV_NAME=image:$IMAGE_NAME:$IMAGE_TAG


### PR DESCRIPTION
without `set -o pipefail`, even if `make train` fails, `| tee` succeeds, which makes execution continue.